### PR TITLE
Feat: add new link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Useful and interesting cryptocurrency websites and resources.
 * [solhint](https://protofire.github.io/solhint/) - An open source project for linting Solidity code. This project provides both Security and Style Guide validations.
 * [Solidity by Example](https://solidity-by-example.org/) - An introduction to Solidity with simple examples.
 * [Solidity documentation](https://docs.soliditylang.org/) - Solidity is an object-oriented, high-level language for implementing smart contracts.
+* [Moralis Development framework](https://moralis.io/) - Moralis provides a single workflow for building high performance dapps. Fully compatible with your favorite web3 tools and services.
 
 # Exchanges
 * [Binance.US](https://www.binance.us/en/home) - Trade over 50 cryptocurrencies with low trading fees.


### PR DESCRIPTION
**Context:** 
Moralis framework was missing in your `Dev Tools`.

**Proposal:** 
I added the direct link to Moralis.io in line `21` for easy access to the website.   

Ivo